### PR TITLE
Add parseCookieName, parseCookieValue methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,20 @@ strictCookieParser.parseCookieHeader('not a cookie')
 
 strictCookieParser.parseCookiePair('single=pair')
 // { name: 'single', value: 'pair' }
+
+strictCookieParser.parseCookieName('foo')
+// 'foo'
+
+strictCookieParser.parseCookieName('m=m')
+// invalid - cookie names cannot contain =
+// null
+
+strictCookieParser.parseCookieValue('"foo"')
+// 'foo'
+
+strictCookieParser.parseCookieValue(' foo')
+// invalid - unquoted cookie values cannot begin with a space
+// null
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ strictCookieParser.parseCookieHeader('not a cookie')
 strictCookieParser.parseCookiePair('single=pair')
 // { name: 'single', value: 'pair' }
 
-strictCookieParser.parseCookieName('foo')
-// 'foo'
+strictCookieParser.isCookieName('foo')
+// true
 
-strictCookieParser.parseCookieName('m=m')
+strictCookieParser.isCookieName('m=m')
 // invalid - cookie names cannot contain =
-// null
+// false
 
 strictCookieParser.parseCookieValue('"foo"')
 // 'foo'

--- a/index.js
+++ b/index.js
@@ -40,14 +40,14 @@ const parseCookieValue = cookieValue => {
 };
 
 const parseCookiePair = cookiePair => {
-	const parts = cookiePair.split('=', 2);
+	const splitAt = cookiePair.indexOf('=');
 
-	if (parts.length !== 2) {
+	if (splitAt === -1) {
 		return null;
 	}
 
-	const name = parts[0];
-	const value = parseCookieValue(parts[1]);
+	const name = cookiePair.slice(0, splitAt);
+	const value = parseCookieValue(cookiePair.slice(splitAt + 1));
 
 	if (!isCookieName(name) || value === null) {
 		return null;

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const COOKIE_NAME = /^([^\x00-\x20\x7f()<>@,;:\\"/[\]?={}]+)$/;
+const COOKIE_NAME = /^[^\x00-\x20\x7f()<>@,;:\\"/[\]?={}]+$/;
 const COOKIE_VALUE = /^(?:([\x21\x23-\x2b\x2d-\x3a\x3c-\x5b\x5d-\x7e]*)|"([\x21\x23-\x2b\x2d-\x3a\x3c-\x5b\x5d-\x7e]*)")$/;
 
 const isOptionalWhitespace = c =>
@@ -27,13 +27,7 @@ const stripCookieHeader = header => {
 	return header.substring(start, end + 1);
 };
 
-const parseCookieName = cookieName => {
-	const nameMatch = COOKIE_NAME.exec(cookieName);
-	if (nameMatch === null) {
-		return null;
-	}
-	return nameMatch[1];
-};
+const isCookieName = cookieName => COOKIE_NAME.test(cookieName);
 
 const parseCookieValue = cookieValue => {
 	const valueMatch = COOKIE_VALUE.exec(cookieValue);
@@ -52,10 +46,10 @@ const parseCookiePair = cookiePair => {
 		return null;
 	}
 
-	const name = parseCookieName(parts[0]);
+	const name = parts[0];
 	const value = parseCookieValue(parts[1]);
 
-	if (name === null || value === null) {
+	if (!isCookieName(name) || value === null) {
 		return null;
 	}
 
@@ -95,7 +89,7 @@ const parseCookieHeader = cookieHeader =>
 	);
 
 module.exports = {
-	parseCookieName,
+	isCookieName,
 	parseCookieValue,
 	parseCookiePair,
 	parseCookieHeader,

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
-const COOKIE_PAIR = /^([^\x00-\x20\x7f()<>@,;:\\"/[\]?={}]+)=(?:([\x21\x23-\x2b\x2d-\x3a\x3c-\x5b\x5d-\x7e]*)|"([\x21\x23-\x2b\x2d-\x3a\x3c-\x5b\x5d-\x7e]*)")$/;
+const COOKIE_NAME = /^([^\x00-\x20\x7f()<>@,;:\\"/[\]?={}]+)$/;
+const COOKIE_VALUE = /^(?:([\x21\x23-\x2b\x2d-\x3a\x3c-\x5b\x5d-\x7e]*)|"([\x21\x23-\x2b\x2d-\x3a\x3c-\x5b\x5d-\x7e]*)")$/;
 
 const isOptionalWhitespace = c =>
 	c === 32 || c === 9;
@@ -26,18 +27,37 @@ const stripCookieHeader = header => {
 	return header.substring(start, end + 1);
 };
 
-const parseCookiePair = cookiePair => {
-	const match = COOKIE_PAIR.exec(cookiePair);
+const parseCookieName = cookieName => {
+	const nameMatch = COOKIE_NAME.exec(cookieName);
+	if (nameMatch === null) {
+		return null;
+	}
+	return nameMatch[1];
+};
 
-	if (match === null) {
+const parseCookieValue = cookieValue => {
+	const valueMatch = COOKIE_VALUE.exec(cookieValue);
+	if (valueMatch === null) {
+		return null;
+	}
+	return valueMatch[1] === undefined ?
+		valueMatch[2] :
+		valueMatch[1];
+};
+
+const parseCookiePair = cookiePair => {
+	const parts = cookiePair.split('=', 2);
+
+	if (parts.length !== 2) {
 		return null;
 	}
 
-	const name = match[1];
-	const value =
-		match[2] === undefined ?
-			match[3] :
-			match[2];
+	const name = parseCookieName(parts[0]);
+	const value = parseCookieValue(parts[1]);
+
+	if (name === null || value === null) {
+		return null;
+	}
 
 	return {
 		name,
@@ -75,6 +95,8 @@ const parseCookieHeader = cookieHeader =>
 	);
 
 module.exports = {
+	parseCookieName,
+	parseCookieValue,
 	parseCookiePair,
 	parseCookieHeader,
 };

--- a/test.js
+++ b/test.js
@@ -4,8 +4,8 @@ const assert = require('assert');
 const test = require('@charmander/test')(module);
 
 const {
+	isCookieName,
 	parseCookieHeader,
-	parseCookieName,
 	parseCookieValue,
 } = require('./');
 
@@ -69,7 +69,7 @@ test('.parseCookieValue works as expected', () => {
 	assert.strictEqual(parseCookieValue('"foo"'), 'foo');
 });
 
-test('.parseCookieName works as expected', () => {
-	assert.strictEqual(parseCookieName('foo'), 'foo');
-	assert.strictEqual(parseCookieName('m=m'), null);
+test('.isCookieName works as expected', () => {
+	assert.strictEqual(isCookieName('foo'), true);
+	assert.strictEqual(isCookieName('m=m'), false);
 });

--- a/test.js
+++ b/test.js
@@ -3,7 +3,11 @@
 const assert = require('assert');
 const test = require('@charmander/test')(module);
 
-const {parseCookieHeader} = require('./');
+const {
+	parseCookieHeader,
+	parseCookieName,
+	parseCookieValue,
+} = require('./');
 
 test('Single unquoted cookies are parsed correctly', () => {
 	const result = parseCookieHeader('hello=world');
@@ -56,4 +60,15 @@ test('Invalid cookies are rejected', () => {
 	assert.strictEqual(parseCookieHeader('a=white space'), null);
 	assert.strictEqual(parseCookieHeader('a=comma,character'), null);
 	assert.strictEqual(parseCookieHeader('a=double"quote'), null);
+});
+
+test('.parseCookieValue works as expected', () => {
+	assert.strictEqual(parseCookieValue(' foo'), null);
+	assert.strictEqual(parseCookieValue('foo'), 'foo');
+	assert.strictEqual(parseCookieValue('"foo"'), 'foo');
+});
+
+test('.parseCookieName works as expected', () => {
+	assert.strictEqual(parseCookieName('foo'), 'foo');
+	assert.strictEqual(parseCookieName('m=m'), null);
 });

--- a/test.js
+++ b/test.js
@@ -13,12 +13,20 @@ test('Single unquoted cookies are parsed correctly', () => {
 	const result = parseCookieHeader('hello=world');
 	assert.notStrictEqual(result, null);
 	assert.strictEqual(result.get('hello'), 'world');
+
+	const result2 = parseCookieHeader('a=b=c');
+	assert.notStrictEqual(result2, null);
+	assert.strictEqual(result2.get('a'), 'b=c');
 });
 
 test('Single quoted cookies are parsed correctly', () => {
 	const result = parseCookieHeader('hello="world"');
 	assert.notStrictEqual(result, null);
 	assert.strictEqual(result.get('hello'), 'world');
+
+	const result2 = parseCookieHeader('a="b=c"');
+	assert.notStrictEqual(result2, null);
+	assert.strictEqual(result2.get('a'), 'b=c');
 });
 
 test('Multiple unquoted cookies are parsed correctly', () => {

--- a/test.js
+++ b/test.js
@@ -60,6 +60,7 @@ test('Invalid cookies are rejected', () => {
 	assert.strictEqual(parseCookieHeader('a=white space'), null);
 	assert.strictEqual(parseCookieHeader('a=comma,character'), null);
 	assert.strictEqual(parseCookieHeader('a=double"quote'), null);
+	assert.strictEqual(parseCookieHeader('name"="foo"'), null);
 });
 
 test('.parseCookieValue works as expected', () => {


### PR DESCRIPTION
I wanted to validate cookie names and values separately, so I updated the code to allow for it. I split the existing regex in half and updated the existing code to use the new functions. All tests pass.